### PR TITLE
fix(docs): research label instead of title

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ To contribute new research:
     - The file title should use [kebab-case](https://www.freecodecamp.org/news/programming-naming-conventions-explained/#what-is-kebab-case).
   - Add the property or properties and the new file to the index in [package-json.md][package-json].
     - Use reference links so they can be reused throughout the file reliably.
-  - The PR title should follow the format: `[research] Property: <property>` or `[research] Properties: <property-1>, <property-2>`.
+  - The PR title should follow the format: `Property: <property>` or `Properties: <property-1>, <property-2>`.
+  - The PR should have the label `research` (if you cannot add labels a contributor will)
 - Once your research is complete, mark the PR as "ready to review".
 
 To contribute to existing research:


### PR DESCRIPTION
I propose we use labels instead of titles. This way we can use the GH filter specially made for this instead of a search. Not a big deal either way, but figured I would propose this as a PR. Also sorry I guess vs code defaults to adding a new line at the end of the file...not sure it matters to remove it though as that is a default setting I think most folks have right?